### PR TITLE
Add -y to help message

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -326,6 +326,7 @@ int main(int argc, char *argv[])
 		fprintf(fp_help, "    -o FILE      output alignments to FILE [stdout]\n");
 		fprintf(fp_help, "    -L           write CIGAR with >65535 ops at the CG tag\n");
 		fprintf(fp_help, "    -R STR       SAM read group line in a format like '@RG\\tID:foo\\tSM:bar' []\n");
+		fprintf(fp_help, "    -y           Copy input FASTA/Q comments to output (especially helpful for MM/ML tags)\n");
 		fprintf(fp_help, "    -c           output CIGAR in PAF\n");
 		fprintf(fp_help, "    --cs[=STR]   output the cs tag; STR is 'short' (if absent) or 'long' [none]\n");
 		fprintf(fp_help, "    --MD         output the MD tag\n");


### PR DESCRIPTION
-y is undocumented in the help message. It's also missing in minimap2's help message, but you can still find it in the minimap2 man page. This option has become more relevant as the need to have modified base information (encoded in MM & ML SAM/BAM tags) has grown. These MM/ML tags can be copied as comments (anything after the first whitespace) into the FASTQ header from the uBAM containing reads (e.g., via samtools fastq -T MM,ML). That FASTQ can be used as input to Winnowmap, and -y allows those tags to be added to the output alignment SAM or PAF. Downstream tools (e.g., modkit) can then use those tags to determine the modified base status from the aligned read evidence.