### PR TITLE
made OMP_PER_READ_THREADS configurable and default to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-export CPPFLAGS= -g -Wall -O2 -DHAVE_KALLOC -fopenmp -std=c++11 -Wno-sign-compare -Wno-write-strings -Wno-unused-but-set-variable -fno-tree-vectorize
+
+OMP_PER_READ_THREADS = 1
+### use `make OMP_PER_READ_THREADS=N` to override the default 1 OMP thead with N threads
+
+export CPPFLAGS= -g -Wall -O2 -DOMP_PER_READ_THREADS=$(OMP_PER_READ_THREADS) -DHAVE_KALLOC -fopenmp -std=c++11 -Wno-sign-compare -Wno-write-strings -Wno-unused-but-set-variable -fno-tree-vectorize
 export LIBS= -lm -lz -lpthread
 export BUILDSTACKTRACE=0 #for meryl
 

--- a/src/minimap.h
+++ b/src/minimap.h
@@ -46,7 +46,6 @@
 
 #define MM_MAX_SEG       255
 
-#define OMP_PER_READ_THREADS 3
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This deals with the overloading observed in issue #30 where the total number of threads was the number of ptreads defined with `-t` times `OMP_PER_READ_THREADS`. In my tests, given a fixed number of CPUs, there was no difference in runtime between `OMP_PER_READ_THREADS=3` and `OMP_PER_READ_THREADS=1`.

- made OMP_PER_READ_THREADS a compile-time configurable with a make argument with a default to 1
- used CPU affinity from `sched.h` to correctly detect the number of allocated/available CPUs in, for example, SLURM jobs rather than all CPUs available on a system
- considered OMP threads when calculating total threads

